### PR TITLE
Add ability to inject error logger

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "morearty",
-  "version": "0.7.25",
+  "version": "0.7.26",
   "description": "Centralized state management for React in pure JavaScript.",
   "homepage": "https://github.com/moreartyjs/moreartyjs",
   "author": "Alexander Semenov",


### PR DESCRIPTION
**What**
Add the `logger` option to `createContext` which lets us specify error logger. 
The error logger is expected to implement `error(message, cause)` method.

**Why**
To be able to inject an error tracker, e.g. Sentry in the Context

**Who**
@gdehmlow, @gerad
