### PR TITLE
Remove `isMounted()` call

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "morearty",
-  "version": "0.7.27",
+  "version": "0.7.28",
   "description": "Centralized state management for React in pure JavaScript.",
   "homepage": "https://github.com/moreartyjs/moreartyjs",
   "author": "Alexander Semenov",

--- a/src/Morearty.js
+++ b/src/Morearty.js
@@ -418,7 +418,7 @@ module.exports = function (React, DOM) {
       };
 
       var forceUpdate = function (comp, f) {
-        if (comp.isMounted()) {
+        if (comp.isMounted) {
           comp.forceUpdate(f);
         }
       };
@@ -666,6 +666,7 @@ module.exports = function (React, DOM) {
         if (this.observedBindings) {
           this.observedBindings.forEach(setupObservedBindingListener.bind(null, this));
         }
+        this.isMounted = true;
       },
 
       shouldComponentUpdate: function (nextProps, nextState, nextContext) {
@@ -731,6 +732,7 @@ module.exports = function (React, DOM) {
           this._bindingListenerRemovers.forEach(function (remover) { remover(); });
           this._bindingListenerRemovers = [];
         }
+        delete this.isMounted;
       }
 
     },


### PR DESCRIPTION
**what**
replace calling the deprecated `isMounted` method with an `isMounted` flag which is set to true on mount and deleted on unmount

**why**
to get rid of all these warnings which clutter the console
<img width="1223" alt="screen shot 2017-12-05 at 11 03 11 am" src="https://user-images.githubusercontent.com/3654181/33588253-e93f8186-d9ac-11e7-9252-885cc7c66b89.png">

NOTE: simplest solution picked from some conversations https://github.com/moreartyjs/moreartyjs/issues/84#issuecomment-110679755 & https://github.com/facebook/react/issues/3417#issuecomment-121649937
