### PR TITLE
Cleaner check for whether component is mounted

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "morearty",
-  "version": "0.7.28",
+  "version": "0.7.29",
   "description": "Centralized state management for React in pure JavaScript.",
   "homepage": "https://github.com/moreartyjs/moreartyjs",
   "author": "Alexander Semenov",

--- a/src/Morearty.js
+++ b/src/Morearty.js
@@ -418,7 +418,7 @@ module.exports = function (React, DOM) {
       };
 
       var forceUpdate = function (comp, f) {
-        if (comp.isMounted) {
+        if (!comp.isUnmounted) {
           comp.forceUpdate(f);
         }
       };
@@ -666,7 +666,10 @@ module.exports = function (React, DOM) {
         if (this.observedBindings) {
           this.observedBindings.forEach(setupObservedBindingListener.bind(null, this));
         }
-        this.isMounted = true;
+      },
+
+      componentDidMount: function () {
+        this.isUnmounted = false;
       },
 
       shouldComponentUpdate: function (nextProps, nextState, nextContext) {
@@ -732,7 +735,7 @@ module.exports = function (React, DOM) {
           this._bindingListenerRemovers.forEach(function (remover) { remover(); });
           this._bindingListenerRemovers = [];
         }
-        delete this.isMounted;
+        this.isUnmounted = true;
       }
 
     },


### PR DESCRIPTION
Unfortunately I noticed some side effects that I missed earlier while testing out the change. After digging around, I found a good example to follow which should remove the side effects from the previous implementation.

<img width="1314" alt="screen shot 2017-12-06 at 10 47 22 am" src="https://user-images.githubusercontent.com/3654181/33642055-1cf20a46-da73-11e7-9045-b7000d5f2143.png">

Based on `isUnmounted` example here: https://github.com/react-bootstrap/react-bootstrap/blob/master/src/CarouselItem.js